### PR TITLE
Feature: additions to smart constructors

### DIFF
--- a/src/Data/Regex/CommonRegexes.idr
+++ b/src/Data/Regex/CommonRegexes.idr
@@ -11,7 +11,7 @@ export
 email : TyRE (String, String, String)
 email = 
     let firstPart : TyRE String
-        firstPart = fastPack `map` rep1 ((letter `or` digitChar) `or` oneOf "%+_.-")
+        firstPart = fastPack `map` rep1 ((letter `or` digitChar) `or` oneOfChars "%+_.-")
         secondPart : TyRE String
         secondPart = (joinBy ".") `map` rep1 (fastPack `map` rep1 (letter `or` digitChar) <* match '.')
         domain : TyRE String
@@ -76,7 +76,7 @@ namespace UrlRegex
           `map` 
           (protocol <*> (host <*> (path <*> (query <*> fragment)))) where
             digitLetterOr : String -> TyRE Char
-            digitLetterOr str = (digitChar `or` letter) `or` oneOf str
+            digitLetterOr str = (digitChar `or` letter) `or` oneOfChars str
             
             protocol : TyRE (Maybe Bool)
             protocol = r "((https?)!://(www)?)?"

--- a/src/TyRE/Core.idr
+++ b/src/TyRE/Core.idr
@@ -3,11 +3,12 @@ module TyRE.Core
 import public Data.List
 import public Data.Either
 import public Data.SortedSet
+import public Data.List1
 import Data.SnocList
 
 import TyRE.CoreRE
 
-infixr 6 <*>
+infixr 6 <*>, <*, *>
 
 public export
 data TyRE : Type -> Type where
@@ -71,16 +72,16 @@ digitChar : TyRE Char
 digitChar = range '0' '9'
 
 public export
-oneOfList : List Char -> TyRE Char
-oneOfList xs = Untyped (CharPred (OneOf (fromList xs)))
+oneOfCharsList : List Char -> TyRE Char
+oneOfCharsList xs = Untyped (CharPred (OneOf (fromList xs)))
 
 public export
-oneOf : String -> TyRE Char
-oneOf xs = oneOfList (unpack xs)
+oneOfChars : String -> TyRE Char
+oneOfChars xs = oneOfCharsList (unpack xs)
 
 public export
 match : Char -> TyRE ()
-match c = ignore $ oneOfList [c]
+match c = ignore $ oneOfCharsList [c]
 
 public export
 rep0 : TyRE a -> TyRE (List a)
@@ -89,6 +90,10 @@ rep0 tyre = cast `map` Rep tyre
 public export
 rep1 : TyRE a -> TyRE (List a)
 rep1 tyre = (\(e,l) => e::l) `map` (tyre <*> rep0 tyre)
+
+public export
+rep1l1 : TyRE a -> TyRE (List1 a)
+rep1l1 tyre = (\(e,l) => e:::l) `map` (tyre <*> rep0 tyre)
 
 public export
 option : TyRE a -> TyRE (Maybe a)
@@ -105,6 +110,11 @@ public export
 public export
 or : TyRE a -> TyRE a -> TyRE a
 or t1 t2 = fromEither `map` (t1 <|> t2)
+
+public export
+oneOf : List1 (TyRE a) -> TyRE a
+oneOf (head ::: []) = head
+oneOf (head ::: (x :: xs)) = oneOf $ (head `or` x) ::: xs
 
 public export
 letter : TyRE Char

--- a/src/TyRE/RE.idr
+++ b/src/TyRE/RE.idr
@@ -163,7 +163,7 @@ mutual
   public export
   compileKeep                  : (re : RE) -> TyRE $ TypeREKeep re
   compileKeep (Exactly x)      = match x
-  compileKeep (OneOf xs)       = oneOfList xs
+  compileKeep (OneOf xs)       = oneOfCharsList xs
   compileKeep (To x y)         = range x y
   compileKeep Any              = any
   compileKeep (Group re)       = group (compileKeep re)
@@ -526,7 +526,7 @@ mutual
   public export
   compile                  : (re : RE) -> TyRE $ TypeRE re
   compile (Exactly x)      = match x
-  compile (OneOf xs)       = ignore (oneOfList xs)
+  compile (OneOf xs)       = ignore (oneOfCharsList xs)
   compile (To x y)         = ignore (range x y)
   compile Any              = ignore any
   compile (Group re)       = Untyped $ Group $ compile $ compile re


### PR DESCRIPTION
1. <*>, *>, <* -- right assoc
2. `oneOf` and `oneOfList` renamed to `oneOfChars`, `oneOfCharsList`
3. added `oneOf` that takes a list of tyre patterns
3. added `rep1l1`, which acts as `rep1` but returns a List1

(Possibly <*>, *>, <* are still visible as left assoc, because of their definition in prelude)
resolves: https://github.com/kasiaMarek/TyRE/issues/39