### PR TITLE
Refactor in routines for readibility

### DIFF
--- a/performance/StarComb.idr
+++ b/performance/StarComb.idr
@@ -1,6 +1,6 @@
-import Text.Lexer
-import public Text.Parser.Core
-import public Text.Parser
+import TyRE.Text.Lexer
+import public TyRE.Text.Parser.Core
+import public TyRE.Text.Parser
 
 data AToken = AChar | EndTok
 

--- a/performance/StarComb.idr
+++ b/performance/StarComb.idr
@@ -1,6 +1,6 @@
-import TyRE.Text.Lexer
-import public TyRE.Text.Parser.Core
-import public TyRE.Text.Parser
+import Text.Lexer
+import public Text.Parser.Core
+import public Text.Parser
 
 data AToken = AChar | EndTok
 


### PR DESCRIPTION
Change in SM, so now a Routine is a list of Instructions. Improves readability and is more intuitive.
Drawback: since `lift` is now a function that traverses all the elements of routine this my badly effect the performance.