### PR TITLE
Single-character matching partial evaluation

### DIFF
--- a/src/TyRE/Core.idr
+++ b/src/TyRE/Core.idr
@@ -8,7 +8,7 @@ import Data.SnocList
 
 infixr 6 <*>, <*, *>
 
-public export 
+public export
 data CharCond =
       OneOf (SortedSet Char)
     | Range (Char, Char)
@@ -24,9 +24,9 @@ Eq CharCond where
 
 public export
 satisfies : CharCond -> Char -> Bool
-satisfies (OneOf xs) c = contains c xs
-satisfies (Range (x, y)) c = x <= c && c <= y
-satisfies (Pred f) c = f c
+satisfies (OneOf xs) = \c => contains c xs
+satisfies (Range (x, y)) = \c => x <= c && c <= y
+satisfies (Pred f) = \c => f c
 
 public export
 data TyRE : Type -> Type where
@@ -131,7 +131,7 @@ repFrom (S k) re = (\(e,l) => e::l) `map` (re <*> repFrom k re)
 public export
 repTo : Nat -> TyRE a -> TyRE (List a)
 repTo 0 re = const [] `map` empty
-repTo (S k) re = 
+repTo (S k) re =
   optionalAdd `map` (option re <*> repTo k re) where
     optionalAdd : (Maybe a, List a) -> List a
     optionalAdd (Nothing, xs) = xs

--- a/src/TyRE/Parser/SMConstruction.idr
+++ b/src/TyRE/Parser/SMConstruction.idr
@@ -25,9 +25,10 @@ compile (MatchChar f) =
       lookup () = [< ]
       init : InitStatesType Char () lookup
       init = [(Just () ** [<] `Element` [<])]
+      match : Char -> Bool := satisfies f
       next : TransitionRelation Char () lookup
       next () c =
-        if satisfies f c
+        if match c
         then [(Nothing ** [< PushChar])]
         else []
   in MkSM () lookup init next


### PR DESCRIPTION
I spotted a potential room for a little optimisation. Need to profile benchmark to see if performance improves a little.

We already know which predicate we need to use to match a single character at regex compile time, there's no point in deferring this check to parse-time.

If we use higher-order functions as a proxy for staged computation, we can implement in the following code.
(Note we need to use `let` binding (`:=`) rather than a local definition to ensure we construct `match` at regex compile time.

+ [ ] profile benchmarks to check whether we gain a little in running time (I don't expect a drastic improvement, but this kind of code is sitting in a tight loop).